### PR TITLE
CarrierConfigOverlay: enable volte & vowifi for Russian carriers

### DIFF
--- a/rro_overlays/CarrierConfigOverlay/res/xml/vendor.xml
+++ b/rro_overlays/CarrierConfigOverlay/res/xml/vendor.xml
@@ -446,8 +446,44 @@
         <int name="carrier_default_wfc_ims_mode_int" value="1" />
         <int name="carrier_default_wfc_ims_roaming_mode_int" value="1" />
     </carrier_config>
+    <carrier_config mcc="250" mnc="01">
+        <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <boolean name="carrier_vt_available_bool" value="true" />
+        <int name="carrier_default_wfc_ims_mode_int" value="2"/>
+        <int name="smsToMmsTextThreshold" value="4"/>
+        <int name="maxMessageSize" value="512000"/>
+        <boolean name="mtk_carrier_wfc_get_location_always" value="true"/>
+    </carrier_config>
     <carrier_config mcc="250" mnc="02">
         <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <int name="carrier_default_wfc_ims_mode_int" value="2"/>
+        <boolean name="config_editable_wfc_when_calling" value="false"/>
+    </carrier_config>
+    <carrier_config mcc="250" mnc="11">
+        <int name="carrier_default_wfc_ims_mode_int" value="2"/>
+    </carrier_config>
+    <carrier_config mcc="250" mnc="20">
+        <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <boolean name="carrier_vt_available_bool" value="true" />
+        <boolean name="mtk_carrier_wfc_get_location_always" value="true"/>
+        <boolean name="carrier_default_wfc_ims_enabled_bool" value="true"/>
+    </carrier_config>
+    <carrier_config mcc="250" mnc="35">
+        <boolean name="carrier_volte_available_bool" value="true" />
+    </carrier_config>
+    <carrier_config mcc="250" mnc="50">
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <int name="carrier_default_wfc_ims_mode_int" value="2"/>
+    </carrier_config>
+    <carrier_config mcc="250" mnc="99">
+        <boolean name="carrier_volte_available_bool" value="true" />
+        <boolean name="carrier_wfc_ims_available_bool" value="true" />
+        <boolean name="config_wifi_disconnect_delay_for_vowifi_detach" value="true"/>
+        <int name="carrier_default_wfc_ims_mode_int" value="2"/>
+        <boolean name="carrier_stk_dialog_timout_customized" value="true"/>
     </carrier_config>
     <carrier_config mcc="259" mnc="01">
         <boolean name="fallback_sms_not_allowed_in_roaming" value="true" />


### PR DESCRIPTION
Configs were taken from MIUI Global 14.0.4.0 package com.android.carrierconfig