### PR TITLE
spes: parts: target current sdk

### DIFF
--- a/parts/AndroidManifest.xml
+++ b/parts/AndroidManifest.xml
@@ -27,15 +27,12 @@
     <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
     <uses-permission android:name="android.permission.VIBRATE" />
 
-    <uses-sdk
-        android:minSdkVersion="30"
-        android:targetSdkVersion="30"/>
-
     <application
         android:label="@string/device_settings_app_name"
         android:persistent="true">
 
-        <receiver android:name=".BootCompletedReceiver" android:exported="true">
+        <receiver android:name=".BootCompletedReceiver"
+                  android:exported="false">
             <intent-filter android:priority="1000">
                 <action android:name="android.intent.action.BOOT_COMPLETED" />
                 <category android:name="android.intent.category.DEFAULT" />
@@ -44,6 +41,7 @@
 
         <service
             android:name=".display.DcDimmingTileService"
+            android:exported="true"
             android:icon="@drawable/ic_dc_tile"
             android:label="@string/dc_dimming_enable_title"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
@@ -55,6 +53,7 @@
 
         <service
             android:name=".display.HBMTileService"
+            android:exported="true"
             android:icon="@drawable/ic_hbm_tile"
             android:label="@string/hbm_mode_title"
             android:permission="android.permission.BIND_QUICK_SETTINGS_TILE">
@@ -88,6 +87,7 @@
 
         <activity
             android:name=".display.DisplaySettingsActivity"
+            android:exported="false"
             android:label="@string/display_settings_title"
             android:theme="@style/Theme.SubSettingsBase">
             <intent-filter>
@@ -104,6 +104,7 @@
 
          <activity
             android:name=".speaker.ClearSpeakerActivity"
+            android:exported="false"
             android:label="@string/clear_speaker_title"
             android:theme="@style/Theme.SubSettingsBase">
             <intent-filter>


### PR DESCRIPTION
Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present